### PR TITLE
make services public

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -7,7 +7,7 @@ services:
   _defaults:
     autowire: true
     autoconfigure: true
-    public: false
+    public: true
 
   _instanceof:
     Contao\CoreBundle\Framework\FrameworkAwareInterface:


### PR DESCRIPTION
Since you are [registering some services as Contao hooks](https://github.com/fipps/contao-parallax-bundle/blob/c146097c6d1952acae20f49292c3781d853b968c/src/Resources/contao/config/config.php#L12-L14), the respective services must be set to public - otherwise Contao cannot retrieve them from the container in Symfony 4.

This PR simply makes all your services public by default.